### PR TITLE
Make config cwd agnostic

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,9 +10,11 @@ var current;
  */
 function read() {
   var nconf = require('nconf'),
+    path = require('path'),
     environment = process.env.NODE_ENV || 'development',
-    yaml = require('nconf-yaml');
-
+    yaml = require('nconf-yaml'),
+    configDir = path.dirname(require.main.filename) + '/config';
+  
   nconf.clear();
   nconf.reset();
 
@@ -40,7 +42,7 @@ function read() {
   // priority #4 - hard-coded values loaded from $NODE_ENV.yml
   nconf.add('environment', {
     type: 'file',
-    file: './config/' + environment + '.yml',
+    file: configDir + '/' + environment + '.yml',
     format: yaml
   });
 
@@ -49,7 +51,7 @@ function read() {
 
   // priority #5 - hard-coded default values loaded from defaults.yml
   nconf.file({
-    file: './config/defaults.yml',
+    file: configDir + '/defaults.yml',
     format: yaml
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@costadigital/node-app",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Common utilities for running a node app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@asinghal 

This is causing issues in prod. 
Note that naught supports passing the cwd which probably fixes this but I don't want to rely on naught's options. I think an app should work the same way regardless on which CWD is being used to start it.